### PR TITLE
Swagger's "Example Value" in "POST /offers" with the right format for 'startTime' and 'startTimezone'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ build/
 .gradle/
 
 local.properties
+
+# Eclipse
+.classpath
+.project
+.settings/
+bin/

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -52,7 +52,8 @@ dependencies {
 
     implementation "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.10.3"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.3"
-	
+    implementation 'io.swagger.core.v3:swagger-annotations:2.0.9'
+
     implementation group: 'org.springframework.security', name: 'spring-security-oauth2-jose', version: '5.3.0.RELEASE'
     implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.3.0.RELEASE'
     implementation group: 'org.springframework.security', name: 'spring-security-oauth2-resource-server', version:'5.3.0.RELEASE'

--- a/lib/src/main/java/org/sharesquare/model/Offer.java
+++ b/lib/src/main/java/org/sharesquare/model/Offer.java
@@ -7,6 +7,8 @@ import org.sharesquare.AbstractShareSquareObject;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -18,14 +20,20 @@ import java.util.UUID;
 public class Offer extends AbstractShareSquareObject {
 
     private String userId;
-    
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startDate;
-    
+
+    @Schema(type = "string", format = "partial-time", example = "23:57")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     private LocalTime startTime;
-    
+
+    @Schema(type = "string", example = "Europe/Paris")
     private ZoneId startTimezone=ZoneId.of("Europe/Berlin");
+
+	public void setStartTimezone(final ZoneId startTimezone) {
+		this.startTimezone = (startTimezone != null) ? startTimezone : ZoneId.of("Europe/Berlin");
+	}
 
     private Location origin;
     private Location destination;


### PR DESCRIPTION
This is how it looked like in the [api-docs](https://share2hub-r2g-api-dev.apps.prod.rd2g.de/v3/api-docs):
```
...
"startDate": {
  "type": "string",
  "format": "date"
},
"startTime": {
  "$ref": "#/components/schemas/LocalTime"
},
"startTimezone": {
  "type": "object",
  "properties": {
    "rules": {
      ...
```
And this is what we want:
```
...
"startDate": {
  "type": "string",
  "format": "date"
},
"startTime": {
  "type": "string",
  "format": "partial-time"
},
"startTimezone": {
  "type": "string"
},
...
```
So the field `startTime` has to use `"partial-time"` as Swagger's format and `"string"` for type. This can generally be done like this:
```
io.swagger.v3.core.util.PrimitiveType.enablePartialTime();
```
or
```
io.swagger.v3.core.util.PrimitiveType.customClasses()
  .put(java.time.LocalTime.class.getName(),
       io.swagger.v3.core.util.PrimitiveType.PARTIAL_TIME);
```
or for individual fields with Swagger's annotation `Schema`.

Decided to use `Schema` because with the other two ways the generated format for the field `startTime` was then correct but the generated example value was `"string"` instead of something like `"11:04"`.

Same with `startTimezone` field.

This comes with the disadvantage that we have swagger dependencies not only in **share-square-hub** but also in **share-square-commons**.