### PR TITLE
Swagger's code generation has no compile issues

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'org.sharesquare.commons'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 
 sourceCompatibility = 8
 targetCompatibility = 8

--- a/lib/src/main/java/org/sharesquare/model/preferences/BooleanPreference.java
+++ b/lib/src/main/java/org/sharesquare/model/preferences/BooleanPreference.java
@@ -10,7 +10,7 @@ import org.sharesquare.model.Preference;
 @EqualsAndHashCode(callSuper=false)
 public class BooleanPreference extends Preference<Boolean> {
 
-	@Schema(allowableValues = {"BooleanPreference"})
+	@Schema(example = "BooleanPreference")
 	private String type = this.getClass().getSimpleName();
 
 	public void setType(String type) {

--- a/lib/src/main/java/org/sharesquare/model/preferences/DoublePreference.java
+++ b/lib/src/main/java/org/sharesquare/model/preferences/DoublePreference.java
@@ -10,7 +10,7 @@ import org.sharesquare.model.Preference;
 @EqualsAndHashCode(callSuper=false)
 public class DoublePreference extends Preference<Double> {
 
-	@Schema(allowableValues = {"DoublePreference"})
+	@Schema(example = "DoublePreference")
 	private String type = this.getClass().getSimpleName();
 
 	public void setType(String type) {

--- a/lib/src/main/java/org/sharesquare/model/preferences/IntegerPreference.java
+++ b/lib/src/main/java/org/sharesquare/model/preferences/IntegerPreference.java
@@ -10,7 +10,7 @@ import org.sharesquare.model.Preference;
 @EqualsAndHashCode(callSuper=false)
 public class IntegerPreference extends Preference<Integer> {
 
-	@Schema(allowableValues = {"IntegerPreference"})
+	@Schema(example = "IntegerPreference")
 	private String type = this.getClass().getSimpleName();
 
 	public void setType(String type) {

--- a/lib/src/main/java/org/sharesquare/model/preferences/PaxGenderPreference.java
+++ b/lib/src/main/java/org/sharesquare/model/preferences/PaxGenderPreference.java
@@ -10,7 +10,7 @@ import org.sharesquare.model.Preference;
 @EqualsAndHashCode(callSuper=false)
 public class PaxGenderPreference extends Preference<PaxGenderValues> {
 
-	@Schema(allowableValues = {"PaxGenderPreference"})
+	@Schema(example = "PaxGenderPreference")
 	private String type = this.getClass().getSimpleName();
 
 	public void setType(String type) {

--- a/lib/src/main/java/org/sharesquare/model/preferences/PaxPetsPreference.java
+++ b/lib/src/main/java/org/sharesquare/model/preferences/PaxPetsPreference.java
@@ -10,7 +10,7 @@ import org.sharesquare.model.Preference;
 @EqualsAndHashCode(callSuper=false)
 public class PaxPetsPreference extends Preference<PaxPetsValues> {
 
-	@Schema(allowableValues = {"PaxPetsPreference"})
+	@Schema(example = "PaxPetsPreference")
 	private String type = this.getClass().getSimpleName();
 
 	public void setType(String type) {

--- a/lib/src/main/java/org/sharesquare/model/preferences/PaxSmokerPreference.java
+++ b/lib/src/main/java/org/sharesquare/model/preferences/PaxSmokerPreference.java
@@ -10,7 +10,7 @@ import org.sharesquare.model.Preference;
 @EqualsAndHashCode(callSuper=false)
 public class PaxSmokerPreference extends Preference<PaxSmokerValues> {
 
-	@Schema(allowableValues = {"PaxSmokerPreference"})
+	@Schema(example = "PaxSmokerPreference")
 	private String type = this.getClass().getSimpleName();
 
 	public void setType(String type) {

--- a/lib/src/main/java/org/sharesquare/model/preferences/StringPreference.java
+++ b/lib/src/main/java/org/sharesquare/model/preferences/StringPreference.java
@@ -10,7 +10,7 @@ import org.sharesquare.model.Preference;
 @EqualsAndHashCode(callSuper=false)
 public class StringPreference extends  Preference<String> {
 
-	@Schema(allowableValues = {"StringPreference"})
+	@Schema(example = "StringPreference")
 	private String type = this.getClass().getSimpleName();
 
 	public void setType(String type) {


### PR DESCRIPTION
When using `allowableValues` for Swagger's annotation `Schema` for `BooleanPreference`'s attribute `type` like the following:
```
@Schema(allowableValues = {"BooleanPreference"})
```
Swagger's api-docs will be generated with this component schema for `BooleanPreference`'s property `type`:
```
"type": {
   "type": "string",
   "enum": ["BooleanPreference"]
}
```
and this will lead to a compile error when using Swagger's code generation for the generated api-docs file. The error is:
```
[ERROR] src/main/java/io/swagger/client/model/BooleanPreference.java:[106,19] getType() in io.swagger.client.model.BooleanPreference cannot override getType() in io.swagger.client.model.Preference
[ERROR]   return type io.swagger.client.model.BooleanPreference.TypeEnum is not compatible with java.lang.String
```
This problem can be solved by using `example` instead of `allowableValues` like this:
```
@Schema(example = "DoublePreference")
```
api-docs is not using the `enum` field anymore:
```
"type": {
   "type": "string",
   "example": "BooleanPreference"
}
```
and the generated java classes compile now.