### PR TITLE
Small data model changes

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'org.sharesquare.commons'
-version = '0.0.2-SNAPSHOT'
+version = '0.0.3-SNAPSHOT'
 
 sourceCompatibility = 8
 targetCompatibility = 8

--- a/lib/src/main/java/org/sharesquare/model/Connector.java
+++ b/lib/src/main/java/org/sharesquare/model/Connector.java
@@ -9,9 +9,6 @@ import java.net.URL;
 @EqualsAndHashCode(callSuper=false)
 public class Connector extends AbstractShareSquareObject {
 
-
-    TargetSystem targetSystem;
-
     URL offerUpdateWebhook;
     URL aliveCheckWebhook;
 

--- a/lib/src/main/java/org/sharesquare/model/Connector.java
+++ b/lib/src/main/java/org/sharesquare/model/Connector.java
@@ -12,9 +12,9 @@ import java.net.URL;
 public class Connector extends AbstractShareSquareObject {
 
 	@Schema(example = "http://pendlernetz.de/api/offers")
-    URL offerUpdateWebhook;
+    private URL offerUpdateWebhook;
 
 	@Schema(example = "http://pendlernetz.de/api/alivecheck")
-    URL aliveCheckWebhook;
+    private URL aliveCheckWebhook;
 
 }

--- a/lib/src/main/java/org/sharesquare/model/Connector.java
+++ b/lib/src/main/java/org/sharesquare/model/Connector.java
@@ -11,10 +11,10 @@ import java.net.URL;
 @EqualsAndHashCode(callSuper=false)
 public class Connector extends AbstractShareSquareObject {
 
-	@Schema(example = "http://pendlernetz.de/api/offers")
+    @Schema(example = "http://pendlernetz.de/api/offers")
     private URL offerUpdateWebhook;
 
-	@Schema(example = "http://pendlernetz.de/api/alivecheck")
+    @Schema(example = "http://pendlernetz.de/api/alivecheck")
     private URL aliveCheckWebhook;
 
 }

--- a/lib/src/main/java/org/sharesquare/model/Connector.java
+++ b/lib/src/main/java/org/sharesquare/model/Connector.java
@@ -4,12 +4,17 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.sharesquare.AbstractShareSquareObject;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.net.URL;
 @Data
 @EqualsAndHashCode(callSuper=false)
 public class Connector extends AbstractShareSquareObject {
 
+	@Schema(example = "http://pendlernetz.de/api/offers")
     URL offerUpdateWebhook;
+
+	@Schema(example = "http://pendlernetz.de/api/alivecheck")
     URL aliveCheckWebhook;
 
 }

--- a/lib/src/main/java/org/sharesquare/model/Offer.java
+++ b/lib/src/main/java/org/sharesquare/model/Offer.java
@@ -40,7 +40,7 @@ public class Offer extends AbstractShareSquareObject {
 
     private List<ContactOption>  contactOptions;
 
-    private List<UUID> targetPlatforms;
+    private List<UUID> targetSystemIds;
 
     private List<Preference> preferences;
 

--- a/lib/src/main/java/org/sharesquare/model/Preference.java
+++ b/lib/src/main/java/org/sharesquare/model/Preference.java
@@ -25,7 +25,7 @@ import org.sharesquare.model.preferences.*;
 })
 public abstract class Preference<T> extends AbstractShareSquareObject {
 
-    String key;
-    T value;
+	private String key;
 
+	private T value;
 }

--- a/lib/src/main/java/org/sharesquare/model/Preference.java
+++ b/lib/src/main/java/org/sharesquare/model/Preference.java
@@ -25,7 +25,7 @@ import org.sharesquare.model.preferences.*;
 })
 public abstract class Preference<T> extends AbstractShareSquareObject {
 
-	private String key;
+    private String key;
 
-	private T value;
+    private T value;
 }

--- a/lib/src/main/java/org/sharesquare/model/TargetSystem.java
+++ b/lib/src/main/java/org/sharesquare/model/TargetSystem.java
@@ -16,4 +16,5 @@ public class TargetSystem extends AbstractShareSquareObject {
     // ISO-639-1 conform
     String contentLanguage;
     String dataProtectionRegulations;
+    Connector connector;
 }

--- a/lib/src/main/java/org/sharesquare/model/TargetSystem.java
+++ b/lib/src/main/java/org/sharesquare/model/TargetSystem.java
@@ -12,12 +12,17 @@ import java.net.URL;
 @EqualsAndHashCode(callSuper=false)
 public class TargetSystem extends AbstractShareSquareObject {
 
-    String name;
-    String description;
+	private String name;
+
+	private String description;
+
     @Schema(example = "http://pendlernetz.de")
-    URL vanityUrl;
+    private URL vanityUrl;
+
     // ISO-639-1 conform
-    String contentLanguage;
-    String dataProtectionRegulations;
-    Connector connector;
+    private String contentLanguage;
+
+    private String dataProtectionRegulations;
+
+    private Connector connector;
 }

--- a/lib/src/main/java/org/sharesquare/model/TargetSystem.java
+++ b/lib/src/main/java/org/sharesquare/model/TargetSystem.java
@@ -12,9 +12,9 @@ import java.net.URL;
 @EqualsAndHashCode(callSuper=false)
 public class TargetSystem extends AbstractShareSquareObject {
 
-	private String name;
+    private String name;
 
-	private String description;
+    private String description;
 
     @Schema(example = "http://pendlernetz.de")
     private URL vanityUrl;

--- a/lib/src/main/java/org/sharesquare/model/TargetSystem.java
+++ b/lib/src/main/java/org/sharesquare/model/TargetSystem.java
@@ -4,6 +4,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.sharesquare.AbstractShareSquareObject;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.net.URL;
 
 @Data
@@ -12,6 +14,7 @@ public class TargetSystem extends AbstractShareSquareObject {
 
     String name;
     String description;
+    @Schema(example = "http://pendlernetz.de")
     URL vanityUrl;
     // ISO-639-1 conform
     String contentLanguage;


### PR DESCRIPTION
Few changes are needed for the share-square-hub target system REST API implementation and it's database integration.
Changes are:
* use the word target system instead of target platform, since they're the same
* use connector as a property of target system and not the other way around
* URL examples for Swagger since default examples are not valid URLs
* data model classes have private attributes